### PR TITLE
docs: SSH/CI notes — auth-mode autodetect and no empty -i

### DIFF
--- a/docs/CODEX.md
+++ b/docs/CODEX.md
@@ -1,6 +1,8 @@
 ## CI: Remote Smoke — SSH quick notes
 - Если у ВМ включён OS Login, используйте `VM_LOGIN=yc-user` (а не `ubuntu`), иначе получите: “OS login info not found…”.
 - Эфемерный ключ через метаданные (`ssh-keys`) работает только при разрешённой авторизации по метаданным; на OS Login-only он игнорируется.
+- `yc compute ssh` теперь сам определяет режим авторизации, `--auth-type` указывать не нужно.
+- Пустой `-i` в `yc compute ssh` больше не нужен: переданный ключ используется автоматически.
 - Три главные причины падений и решения:
   1) **yc не найден (exit 127)** → ставим `yc`, добавляем в PATH в *том же шаге*.
   2) **yc init с SA JSON** → используем `yc config profile activate` и `yc config set service-account-key sa.json`.


### PR DESCRIPTION
## Summary
- document ssh auth-mode autodetect
- mention removal of empty `-i` flag

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'services')*
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b061707ecc832a93447943002cb717