### PR TITLE
ci(remote-smoke): detect SSH auth mode; avoid empty -i; adaptive login/tunnel

### DIFF
--- a/.github/workflows/remote-smoke.yml
+++ b/.github/workflows/remote-smoke.yml
@@ -75,7 +75,13 @@ jobs:
         run: |
           set -euo pipefail
           key="${{ steps.keygen.outputs.key }}"
-          yc compute ssh --name "$VM_NAME" --login "yc-user" -i "" -- '
+          LOGIN="$VM_LOGIN"
+          IOPT=(-i "$key")
+          if ! yc compute ssh --name "$VM_NAME" --login "$LOGIN" "${IOPT[@]}" -- 'true' >/dev/null 2>&1; then
+            LOGIN="yc-user"
+            IOPT=()
+          fi
+          yc compute ssh --name "$VM_NAME" --login "$LOGIN" "${IOPT[@]}" -- '
             set -euo pipefail
             export DEBIAN_FRONTEND=noninteractive
             # 0) git/docker при необходимости
@@ -111,7 +117,13 @@ jobs:
         run: |
           set -euo pipefail
           key="${{ steps.keygen.outputs.key }}"
-          yc compute ssh --name "$VM_NAME" --login "yc-user" -i "" -- \
+          LOGIN="$VM_LOGIN"
+          IOPT=(-i "$key")
+          if ! yc compute ssh --name "$VM_NAME" --login "$LOGIN" "${IOPT[@]}" -- 'true' >/dev/null 2>&1; then
+            LOGIN="yc-user"
+            IOPT=()
+          fi
+          yc compute ssh --name "$VM_NAME" --login "$LOGIN" "${IOPT[@]}" -- \
             -fNT -L 18000:127.0.0.1:8000 -o ExitOnForwardFailure=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=3
           sleep 1
           nc -zv 127.0.0.1 18000


### PR DESCRIPTION
## Summary
- detect working SSH auth mode and dynamically choose login
- avoid empty `-i` by using optional identity array
- reuse adaptive login/identity for SSH tunnel

## Testing
- `yamllint .github/workflows/remote-smoke.yml` *(fails: line too long)*

------
https://chatgpt.com/codex/tasks/task_e_68b0616c0244832a8efabf1ca283114a