### PR TITLE
Expose API port in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ python -m services.workers.autopilot_runner
 cd services/admin-ui && (pnpm i || npm i) && (pnpm dev --host 127.0.0.1 || npm run dev -- --host 127.0.0.1)
 
 ## Проверка
+- API health: http://127.0.0.1:8000/api/health (порт 8000 проброшен наружу)
 - API metrics: http://127.0.0.1:8000/metrics
 - Grafana:     http://127.0.0.1:3000
 - Prometheus:  http://127.0.0.1:9090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: bfl-api
     working_dir: /app
     ports:
+      - "8000:8000"
     volumes:
       - ./services/ui/dist:/app/ui/dist:ro
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- map API service to host port 8000 in docker-compose
- document exposed API port in README

## Testing
- `docker compose up -d` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `curl -sSf http://localhost:8000/api/health` *(fails: Failed to connect to server)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'services')*

------
https://chatgpt.com/codex/tasks/task_e_68b06f61a160832aa28b438abe097db9