### PR TITLE
chore: remove stale Dockerfile and document build path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,0 @@
-
-# BFL auth login dep
-RUN pip install --no-cache-dir python-multipart

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ cd services/admin-ui && (pnpm i || npm i) && (pnpm dev --host 127.0.0.1 || npm r
 - Prometheus:  http://127.0.0.1:9090
 - Alertmanager:http://127.0.0.1:9093
 - Admin-UI:    http://127.0.0.1:5173
+## Сборка Docker-образа API
+docker build -f services/api/Dockerfile -t bfl-api .  # контекст: корень репо
 
 ## Автопилот (через API)
 curl -X POST http://localhost:8000/api/admin/autopilot/tasks -H 'Content-Type: application/json' -d '{"type":"noop","payload":{}}'


### PR DESCRIPTION
## Summary
- drop unused top-level Dockerfile to avoid confusion with services/api
- document how to build the API image with services/api/Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b06f635c64832aa8a4a880fe69645d