### PR TITLE
Fix: Operator Console uses -R REPO for gh

### DIFF
--- a/.github/workflows/operator-console.yml
+++ b/.github/workflows/operator-console.yml
@@ -1,0 +1,79 @@
+name: Operator Console
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "What to run"
+        type: choice
+        options: [oslogin_sa, oslogin_user, grant_oslogin, provision, quick_smoke]
+        required: true
+      organization_id:
+        description: "YC org id (for oslogin_*)"
+        required: false
+      subject:
+        description: "SA id or user login/email (for oslogin_*/grant)"
+        required: false
+      os_login:
+        description: "OS login"
+        default: "yc-user"
+        required: false
+      uid:
+        description: "UID"
+        default: "20000"
+        required: false
+      ref:
+        description: "Git ref for provision (unused)"
+        default: "main"
+        required: false
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      OSLOGIN_WF: yc-oslogin-profile-create.yml
+      GRANT_WF: yc-grant-oslogin.yml
+      PROVISION_WF: yc-provision.yml
+      SMOKE_WF: yc-quick-smoke.yml
+    steps:
+      - name: Dispatch selected workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ inputs.action }}" in
+            oslogin_sa)
+              gh workflow run "$OSLOGIN_WF" \
+                -f organization_id="${{ inputs.organization_id }}" \
+                -f subject_type="serviceAccount" \
+                -f subject="${{ inputs.subject }}" \
+                -f os_login="${{ inputs.os_login }}" \
+                -f uid="${{ inputs.uid }}"
+              ;;
+            oslogin_user)
+              gh workflow run "$OSLOGIN_WF" \
+                -f organization_id="${{ inputs.organization_id }}" \
+                -f subject_type="yandexPassportUserAccount" \
+                -f subject="${{ inputs.subject }}" \
+                -f os_login="${{ inputs.os_login }}" \
+                -f uid="${{ inputs.uid }}"
+              ;;
+            grant_oslogin)
+              gh workflow run "$GRANT_WF" \
+                -f subject_type="yandexPassportUserAccount" \
+                -f subject="${{ inputs.subject }}" \
+                -f role="compute.osLogin"
+              ;;
+            provision)
+              gh workflow run "$PROVISION_WF" -f debug="false"
+              ;;
+            quick_smoke)
+              gh workflow run "$SMOKE_WF"
+              ;;
+          esac
+          echo "Dispatched: ${{ inputs.action }}"

--- a/.github/workflows/operator-console.yml
+++ b/.github/workflows/operator-console.yml
@@ -48,7 +48,7 @@ jobs:
           set -euo pipefail
           case "${{ inputs.action }}" in
             oslogin_sa)
-              gh workflow run "$OSLOGIN_WF" \
+              gh workflow run -R "$REPO" "$OSLOGIN_WF" \
                 -f organization_id="${{ inputs.organization_id }}" \
                 -f subject_type="serviceAccount" \
                 -f subject="${{ inputs.subject }}" \
@@ -56,7 +56,7 @@ jobs:
                 -f uid="${{ inputs.uid }}"
               ;;
             oslogin_user)
-              gh workflow run "$OSLOGIN_WF" \
+              gh workflow run -R "$REPO" "$OSLOGIN_WF" \
                 -f organization_id="${{ inputs.organization_id }}" \
                 -f subject_type="yandexPassportUserAccount" \
                 -f subject="${{ inputs.subject }}" \
@@ -64,16 +64,16 @@ jobs:
                 -f uid="${{ inputs.uid }}"
               ;;
             grant_oslogin)
-              gh workflow run "$GRANT_WF" \
+              gh workflow run -R "$REPO" "$GRANT_WF" \
                 -f subject_type="yandexPassportUserAccount" \
                 -f subject="${{ inputs.subject }}" \
                 -f role="compute.osLogin"
               ;;
             provision)
-              gh workflow run "$PROVISION_WF" -f debug="false"
+              gh workflow run -R "$REPO" "$PROVISION_WF" -f debug="false"
               ;;
             quick_smoke)
-              gh workflow run "$SMOKE_WF"
+              gh workflow run -R "$REPO" "$SMOKE_WF"
               ;;
           esac
           echo "Dispatched: ${{ inputs.action }}"

--- a/.github/workflows/yc-grant-oslogin.yml
+++ b/.github/workflows/yc-grant-oslogin.yml
@@ -1,0 +1,65 @@
+name: YC Grant OS Login (for local SSH)
+
+on:
+  workflow_dispatch:
+    inputs:
+      subject_type:
+        description: "yandexPassportUserAccount"
+        default: "yandexPassportUserAccount"
+        required: true
+      subject:
+        description: "user id | login | email"
+        required: true
+      role:
+        description: "Role to grant (compute.osLogin or compute.osAdminLogin)"
+        default: "compute.osLogin"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  grant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install yc CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
+          echo "$HOME/yandex-cloud/bin" >> "$GITHUB_PATH"
+      - name: Auth as service account
+        env:
+          YC_SA_KEY_JSON: ${{ secrets.YC_SA_KEY_JSON }}
+          YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
+          YC_FOLDER_ID: ${{ secrets.YC_FOLDER_ID }}
+        run: |
+          printf "%s" "$YC_SA_KEY_JSON" > key.json
+          yc config profile create ci
+          yc config set service-account-key key.json
+          yc config set cloud-id "$YC_CLOUD_ID"
+          yc config set folder-id "$YC_FOLDER_ID"
+      - name: Resolve user id
+        id: resolve
+        env:
+          SUBJECT: ${{ inputs.subject }}
+        run: |
+          set -euo pipefail
+          # Try direct by id/login/email
+          UID=$(yc iam user-account get "$SUBJECT" --format json 2>/dev/null | jq -r '.id' || true)
+          if [[ -z "${UID:-}" ]]; then
+            echo "Could not resolve user with 'yc iam user-account get'. If user is federated org user, pass its user ID." >&2
+            exit 1
+          fi
+          echo "uid=$UID" >> "$GITHUB_OUTPUT"
+      - name: Grant role on folder
+        env:
+          ROLE: ${{ inputs.role }}
+          FOLDER: ${{ secrets.YC_FOLDER_ID }}
+          UID: ${{ steps.resolve.outputs.uid }}
+        run: |
+          yc resource-manager folder add-access-binding "$FOLDER" \
+            --role "$ROLE" \
+            --subject "userAccount:${UID}"
+      - name: Show bindings
+        env:
+          FOLDER: ${{ secrets.YC_FOLDER_ID }}
+        run: yc resource-manager folder list-access-bindings "$FOLDER" --format yaml | sed -e 's/private_key: .*/private_key: REDACTED/'

--- a/.github/workflows/yc-oslogin-profile-create.yml
+++ b/.github/workflows/yc-oslogin-profile-create.yml
@@ -1,0 +1,87 @@
+name: YC OS Login Profile Create (Codex-first)
+
+on:
+  workflow_dispatch:
+    inputs:
+      organization_id:
+        description: "YC organization id"
+        required: true
+      subject_type:
+        description: "serviceAccount | yandexPassportUserAccount"
+        required: true
+      subject:
+        description: "SA id | user id | login | email"
+        required: true
+      os_login:
+        description: "OS login (Linux user)"
+        default: "yc-user"
+        required: true
+      uid:
+        description: "POSIX uid"
+        default: "20000"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install yc CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
+          echo "$HOME/yandex-cloud/bin" >> "$GITHUB_PATH"
+      - name: Auth as service account
+        env:
+          YC_SA_KEY_JSON: ${{ secrets.YC_SA_KEY_JSON }}
+          YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
+          YC_FOLDER_ID: ${{ secrets.YC_FOLDER_ID }}
+        run: |
+          mkdir -p ~/.config/yandex-cloud
+          printf "%s" "$YC_SA_KEY_JSON" > key.json
+          yc config profile create ci
+          yc config set service-account-key key.json
+          yc config set cloud-id "$YC_CLOUD_ID"
+          yc config set folder-id "$YC_FOLDER_ID"
+          yc --version
+      - name: Resolve subject-id (for user emails/logins)
+        id: resolve
+        env:
+          ORG: ${{ inputs.organization_id }}
+          SUBJECT_TYPE: ${{ inputs.subject_type }}
+          SUBJECT: ${{ inputs.subject }}
+        run: |
+          set -euo pipefail
+          SID="$SUBJECT"
+          if [[ "$SUBJECT_TYPE" == "yandexPassportUserAccount" ]]; then
+            SID=$(yc organization-manager user list --organization-id "$ORG" --format json \
+              | jq -r --arg q "$SUBJECT" '
+                .users[] | select(
+                  (.yandex_passport_user_account.default_email == $q) or
+                  (.yandex_passport_user_account.login == $q) or
+                  (.id == $q)
+                ) | .id' | head -n1)
+            if [[ -z "${SID:-}" ]]; then
+              echo "Could not resolve user id for: $SUBJECT" >&2
+              exit 1
+            fi
+          fi
+          echo "sid=$SID" >> "$GITHUB_OUTPUT"
+      - name: Create OS Login profile
+        run: |
+          yc organization-manager oslogin profile create \
+            --organization-id "${{ inputs.organization_id }}" \
+            --subject-id "${{ steps.resolve.outputs.sid || inputs.subject }}" \
+            --login "${{ inputs.os_login }}" \
+            --uid "${{ inputs.uid }}"
+      - name: Dump profile info
+        run: |
+          yc organization-manager oslogin profile get \
+            --organization-id "${{ inputs.organization_id }}" \
+            --subject-id "${{ steps.resolve.outputs.sid || inputs.subject }}" \
+            --format yaml | tee oslogin-profile-create.yaml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: oslogin-profile-create
+          path: oslogin-profile-create.yaml

--- a/.github/workflows/yc-provision.yml
+++ b/.github/workflows/yc-provision.yml
@@ -1,0 +1,98 @@
+name: YC Provision (manual, safe, loopback)
+
+on:
+  workflow_dispatch:
+    inputs:
+      debug:
+        description: "Verbose set -x"
+        default: "false"
+        required: true
+
+permissions:
+  contents: read
+
+env:
+  INSTANCE_NAME: bfl-onprem
+  SSH_LOGIN: yc-user
+  TUNNEL_LOCAL: "18000"
+  TUNNEL_REMOTE: "127.0.0.1:8000"
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install yc CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
+          echo "$HOME/yandex-cloud/bin" >> "$GITHUB_PATH"
+      - name: Auth as service account
+        env:
+          YC_SA_KEY_JSON: ${{ secrets.YC_SA_KEY_JSON }}
+          YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
+          YC_FOLDER_ID: ${{ secrets.YC_FOLDER_ID }}
+        run: |
+          printf "%s" "$YC_SA_KEY_JSON" > key.json
+          yc config profile create ci
+          yc config set service-account-key key.json
+          yc config set cloud-id "$YC_CLOUD_ID"
+          yc config set folder-id "$YC_FOLDER_ID"
+
+      - name: Ensure instance running
+        run: |
+          set -euo pipefail
+          ID=$(yc compute instance get --name "$INSTANCE_NAME" --format json | jq -r '.id')
+          STATUS=$(yc compute instance get "$ID" --format json | jq -r '.status')
+          if [[ "$STATUS" != "RUNNING" ]]; then
+            yc compute instance start "$ID"
+            yc compute instance wait-until-running "$ID"
+          fi
+          echo "id=$ID" >> "$GITHUB_OUTPUT"
+
+      - name: Open NAT window (assign public IP)
+        id: nat_on
+        run: |
+          set -euo pipefail
+          ID=$(yc compute instance get --name "$INSTANCE_NAME" --format json | jq -r '.id')
+          yc compute instance add-one-to-one-nat --id "$ID" --network-interface-index 0
+          PUBLIC_IP=$(yc compute instance get "$ID" --format json | jq -r '.network_interfaces[0].primary_v4_address.one_to_one_nat.address')
+          echo "public_ip=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Remote provision (if script exists)
+        run: |
+          set -euo pipefail
+          # Выполняем провижен только если есть сценарий на ВМ
+          yc compute ssh --name "$INSTANCE_NAME" --login "$SSH_LOGIN" --command 'test -x /opt/bfl/provision.sh' \
+          && yc compute ssh --name "$INSTANCE_NAME" --login "$SSH_LOGIN" -- -o StrictHostKeyChecking=no 'sudo /opt/bfl/provision.sh' \
+          || echo "No /opt/bfl/provision.sh on VM; skipping app deploy"
+
+      - name: Health checks via SSH tunnel
+        run: |
+          set -euo pipefail
+          yc compute ssh --name "$INSTANCE_NAME" --login "$SSH_LOGIN" -- -N -L "${TUNNEL_LOCAL}:${TUNNEL_REMOTE}" -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=no &
+          TID=$!
+          for i in {1..20}; do
+            curl -fsS "http://127.0.0.1:${TUNNEL_LOCAL}/livez" && break || sleep 1
+          done
+          {
+            echo "# Provision health"
+            for p in livez readyz api/health; do
+              printf "%-10s " "$p"
+              curl -fsS "http://127.0.0.1:${TUNNEL_LOCAL}/$p" | head -c 200 || true
+              echo
+            done
+            printf "%-10s " "metrics(HEAD)"; curl -sI "http://127.0.0.1:${TUNNEL_LOCAL}/metrics" | head -n1 || true
+          } | tee provision-logs.txt
+          kill $TID || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: provision-logs
+          path: |
+            provision-logs.txt
+
+      - name: Close NAT window (always)
+        if: always()
+        run: |
+          set -euo pipefail
+          ID=$(yc compute instance get --name "$INSTANCE_NAME" --format json | jq -r '.id')
+          yc compute instance remove-one-to-one-nat --id "$ID" --network-interface-index 0 || true

--- a/.github/workflows/yc-quick-smoke.yml
+++ b/.github/workflows/yc-quick-smoke.yml
@@ -1,0 +1,81 @@
+name: YC Quick Smoke (tunnel-only)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  INSTANCE_NAME: bfl-onprem
+  SSH_LOGIN: yc-user
+  TUNNEL_LOCAL: "18000"
+  TUNNEL_REMOTE: "127.0.0.1:8000"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install yc CLI
+        run: |
+          curl -sSL https://storage.yandexcloud.net/yandexcloud-yc/install.sh | bash
+          echo "$HOME/yandex-cloud/bin" >> "$GITHUB_PATH"
+      - name: Auth as service account
+        env:
+          YC_SA_KEY_JSON: ${{ secrets.YC_SA_KEY_JSON }}
+          YC_CLOUD_ID: ${{ secrets.YC_CLOUD_ID }}
+          YC_FOLDER_ID: ${{ secrets.YC_FOLDER_ID }}
+        run: |
+          printf "%s" "$YC_SA_KEY_JSON" > key.json
+          yc config profile create ci
+          yc config set service-account-key key.json
+          yc config set cloud-id "$YC_CLOUD_ID"
+          yc config set folder-id "$YC_FOLDER_ID"
+
+      - name: Open NAT window
+        id: nat_on
+        run: |
+          ID=$(yc compute instance get --name "$INSTANCE_NAME" --format json | jq -r '.id')
+          yc compute instance add-one-to-one-nat --id "$ID" --network-interface-index 0
+          PUBLIC_IP=$(yc compute instance get "$ID" --format json | jq -r '.network_interfaces[0].primary_v4_address.one_to_one_nat.address')
+          echo "public_ip=$PUBLIC_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Wait SSH & open tunnel
+        run: |
+          set -euo pipefail
+          # короткая проверка ssh
+          for i in {1..30}; do
+            yc compute ssh --name "$INSTANCE_NAME" --login "$SSH_LOGIN" --command 'echo ok' && break || sleep 2
+          done
+          # стартуем туннель в фоне
+          yc compute ssh --name "$INSTANCE_NAME" --login "$SSH_LOGIN" -- -N -L "${TUNNEL_LOCAL}:${TUNNEL_REMOTE}" -o ExitOnForwardFailure=yes -o StrictHostKeyChecking=no &
+          echo $! > tunnel.pid
+          sleep 2
+
+      - name: Check endpoints
+        run: |
+          set -euo pipefail
+          {
+            echo "# Quick smoke"
+            for p in livez readyz api/health; do
+              printf "%-10s " "$p"
+              (curl -fsS "http://127.0.0.1:${TUNNEL_LOCAL}/$p" | head -c 200 && echo "  [OK]") || echo "  [FAIL]"
+            done
+            printf "%-10s " "metrics(HEAD)"; (curl -sI "http://127.0.0.1:${TUNNEL_LOCAL}/metrics" | head -n1 && echo "  [OK]") || echo "  [FAIL]"
+          } | tee quick-smoke-logs.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: quick-smoke-logs
+          path: quick-smoke-logs.txt
+
+      - name: Kill tunnel
+        if: always()
+        run: |
+          kill $(cat tunnel.pid) 2>/dev/null || true
+
+      - name: Close NAT window
+        if: always()
+        run: |
+          ID=$(yc compute instance get --name "$INSTANCE_NAME" --format json | jq -r '.id')
+          yc compute instance remove-one-to-one-nat --id "$ID" --network-interface-index 0 || true


### PR DESCRIPTION
Without -R, gh had no repo context on runners; dispatch failed.