### PR TITLE
fix: wrapper uid string + fromJSON()

### DIFF
--- a/.github/workflows/yc-grant-oslogin-wrapper.yml
+++ b/.github/workflows/yc-grant-oslogin-wrapper.yml
@@ -3,27 +3,22 @@ on:
   workflow_dispatch:
     inputs:
       organization_id:
-        type: string
         description: "YC organization id"
         required: true
       subject_type:
-        type: string
         description: "yandexPassportUserAccount | serviceAccount"
         required: true
       subject:
-        type: string
         description: "email | login | id"
         required: true
       os_login:
-        type: string
         description: "OS login (Linux user)"
         default: "yc-user"
         required: true
       uid:
-        type: number
         description: "POSIX uid"
-        default: 20000
-        required: true
+        default: "20000"      # string!
+        required: false
 jobs:
   run:
     uses: ./.github/workflows/yc-grant-oslogin.yml
@@ -32,5 +27,5 @@ jobs:
       subject_type:     ${{ inputs.subject_type }}
       subject:          ${{ inputs.subject }}
       os_login:         ${{ inputs.os_login }}
-      uid:              ${{ inputs.uid }}
+      uid:              ${{ fromJSON(inputs.uid) }}   # cast string -> number
     secrets: inherit


### PR DESCRIPTION
workflow_dispatch uses string; cast to number for reusable