### PR TITLE
ci: pin actions to SHAs (+optional concurrency)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: ShellCheck
         run: |
           set -euo pipefail

--- a/.github/workflows/run-oslogin-reprovision.yml
+++ b/.github/workflows/run-oslogin-reprovision.yml
@@ -21,7 +21,7 @@ on:
         default: false
 jobs:
   call:
-    uses: MaksimProkopyev/bfl-onprem-public/.github/workflows/oslogin-reprovision.yml@ci/remote-smoke-modes-yc-path-codex-20250829
+    uses: MaksimProkopyev/bfl-onprem-public/.github/workflows/oslogin-reprovision.yml@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/commits/commits#get-a-commit","status":"404"}
     with:
       apply_sg_fix: ${{ inputs.apply_sg_fix }}
       cleanup_old: ${{ inputs.cleanup_old }}

--- a/.github/workflows/yc-autopilot-prepare.yml
+++ b/.github/workflows/yc-autopilot-prepare.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955
       - name: Install deps
         shell: bash
         run: |

--- a/tools/actions-pin-report.md
+++ b/tools/actions-pin-report.md
@@ -1,0 +1,12 @@
+# Actions pin report (2025-09-16 17:47:05 UTC)
+
+  + pinned: actions/checkout@v4 → 08eba0b27e820071cde6df949e0beb9ba4906955
+  + pinned: MaksimProkopyev/bfl-onprem-public/.github/workflows/oslogin-reprovision.yml@ci/remote-smoke-modes-yc-path-codex-20250829 → {"message":"Not Found","documentation_url":"https://docs.github.com/rest/commits/commits#get-a-commit","status":"404"}
+  + concurrency added to .github/workflows/run-oslogin-reprovision.yml
+  + pinned: actions/checkout@v4 → 08eba0b27e820071cde6df949e0beb9ba4906955
+  + concurrency added to .github/workflows/yc-grant-oslogin-wrapper.yml
+  + concurrency added to .github/workflows/yc-grant-oslogin.yml
+  + concurrency added to .github/workflows/yc-instance-power-wrapper.yml
+  + concurrency added to .github/workflows/yc-instance-power.yml
+
+changed: 8 file(s)


### PR DESCRIPTION
Automated pin of external GitHub Actions in `.github/workflows` to commit SHAs.\n\nSee report: `tools/actions-pin-report.md`\n\n- idempotent, skips local `./` and already pinned\n- (optional) added `concurrency` when missing\n\n@codex review